### PR TITLE
Check if circuit breaker is open in __exit__ method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ deploy:
     tags: true
     distributions: "sdist bdist_wheel"
     repo: luizalabs/django-toolkit
+  skip_cleanup: true

--- a/django_toolkit/fallbacks/circuit_breaker.py
+++ b/django_toolkit/fallbacks/circuit_breaker.py
@@ -47,6 +47,8 @@ class CircuitBreaker:
         if self.is_circuit_open:
             raise self.max_failure_exception
 
+        return self
+
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type in self.catch_exceptions:
 

--- a/django_toolkit/fallbacks/circuit_breaker.py
+++ b/django_toolkit/fallbacks/circuit_breaker.py
@@ -51,6 +51,8 @@ class CircuitBreaker:
 
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type in self.catch_exceptions:
+            if self.is_circuit_open:
+                raise self.max_failure_exception
 
             self._increase_failure_count()
 

--- a/django_toolkit/fallbacks/circuit_breaker.py
+++ b/django_toolkit/fallbacks/circuit_breaker.py
@@ -34,14 +34,14 @@ class CircuitBreaker:
         return self.cache.get(self.failure_cache_key) or 0
 
     def open_circuit(self):
+        self.cache.set(self.circuit_cache_key, True, self.circuit_timeout)
+
         logger.critical(
             'Open circuit for {failure_cache_key} {cicuit_cache_key}'.format(
                 failure_cache_key=self.failure_cache_key,
                 cicuit_cache_key=self.circuit_cache_key
             )
         )
-
-        self.cache.set(self.circuit_cache_key, True, self.circuit_timeout)
 
     def __enter__(self):
         if self.is_circuit_open:


### PR DESCRIPTION
Prevents circuit breaker from calling `open_circuit` multiple times and keeps the failure count limit at `max_failures`.