### PR TITLE
Fix distributions key at .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ after_success:
 deploy:
   provider: pypi
   user: luizalabs
+  distributions: "sdist bdist_wheel"
   password:
     secure: P0tYDziArYdHogReZ1x7z4DOR0s1YptI2F/dKWFShJLimQ0GtgAouZF4e2FdxgCdMfzJhZUQl6YXWrumqVbWmF/9R2BXeUQgJbPiK5dQkG5tPPLjXlFZ+9dktH86TerOgcLvXAQVFSkgtGbDHt7XOU43jg3u2UQGyezJnXqRg2mNRNC9oa2mAhIl4Qi4cZZ3V2CMJiz3z+dz3lJpKM5IyqSsCRsuC2piQqO1GsT3MiPZtVGM998n7Cc0zhKplo6+qzVsyobgEO+YnVOU55RYNzof81dtg5WwHeyTSB1oQwXq/8dTtMirLgTaC5qaPRCsnchUL7PX0ilJHI2KuiZwR+NVzQAJ5bZeN+cx5ITnKPKGxw0k0PNUko+q44aLb77kRWj54GQMYqUEIt/Xczw51FjAKECtchcwtXtZlebzN+hG9Y9K9PtYREe9Fki0z7XnSAbeNzBuZCQf0Nvbhot6iEYgDSdSWPVzu+qtHBhi2HNTvlpUgPl1riBxUkiuSwA1mQCTOHwvLDn0z/PS2Lk72aIF+6EO/Sa9tcI30zhLkRUEHn3/qRh46sOQBhmOM4lgtbdQNjda8I0yXH5OZzXUIWAdYKwPG6jHvri8Qkd1jxy0+G+44AfCrRR86j/Q63r78dOpBNxSrwzBBMhzdGLjRWV01nK5OWnkCYiw3Es/p2o=
   on:
     tags: true
-    distributions: "sdist bdist_wheel"
     repo: luizalabs/django-toolkit
   skip_cleanup: true


### PR DESCRIPTION
Looking at [Ramos .travis.yml file](https://github.com/luizalabs/ramos/blob/master/.travis.yml#L24) (which is publishing wheels) we found out our `distributions` key was in a different place.