### PR TITLE
[PROPOSAL] Use cache backend default timeout when expire param is not given.

### DIFF
--- a/django_toolkit/concurrent/locks.py
+++ b/django_toolkit/concurrent/locks.py
@@ -1,4 +1,5 @@
 from django.core.cache import caches
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 
 class LockActiveError(Exception):
@@ -43,7 +44,7 @@ class CacheLock(Lock):
         self,
         key,
         cache_alias='default',
-        expire=0,
+        expire=DEFAULT_TIMEOUT,
         raise_exception=True
     ):
         super(CacheLock, self).__init__()

--- a/docs/concurrent.md
+++ b/docs/concurrent.md
@@ -37,6 +37,7 @@ Django cache alias.
 `expire`
 
 Time in seconds to expire the cache.
+This argument defaults to the backend timeout configuration.
 
 `raise_exception`
 

--- a/tests/concurrent/test_locks.py
+++ b/tests/concurrent/test_locks.py
@@ -57,3 +57,11 @@ class TestCacheLock:
 
             with CacheLock(key='test', raise_exception=False) as lock:
                 assert lock.active is False
+
+    def test_should_use_default_cache_timeout_when_expire_is_not_given(self):
+        with CacheLock(cache_alias='explicit_timeout', key='test') as lock:
+            assert lock.cache.get(lock._key)
+
+    def test_should_expire_immediately_when_expire_is_zero(self):
+        with CacheLock(key='test', expire=0) as lock:
+            assert not lock.cache.get(lock._key)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,7 +32,11 @@ CACHES = {
     },
     'access_token': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
+    },
+    'explicit_timeout': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'TIMEOUT': 300,
+    },
 }
 
 TOOLKIT = {


### PR DESCRIPTION
Change default behaviour from immediate expire to get expiration from backend timeout configuration.

It will make CacheLock interface more consistent with Django cache expected behaviour.

--

Additional notes:

A cache lock is meant to be used to prevent concurrent and distributed access to some resource. In my opinion, the previous behaviour was not the best one (I think immediate expire was not intentional in that implemenation). Another approach would be changing `expire` parameter from optional to required, but I think using default Django cache behaviour would be more benefit.

Software that used previous versions may be upgrade carefully, it might be better to make the new release a major one.