### PR TITLE
Fix wrong lock release when CacheLock is used with raise_exception=False

### DIFF
--- a/django_toolkit/concurrent/locks.py
+++ b/django_toolkit/concurrent/locks.py
@@ -62,5 +62,7 @@ class CacheLock(Lock):
         return self
 
     def __exit__(self, *args, **kwargs):
+        if self.active:
+            self.cache.delete(self._key)
+
         self.active = False
-        self.cache.delete(self._key)


### PR DESCRIPTION
When the lock was not acquired successfully, the __exit__ handler
was releasing the lock anyway.