### PR TITLE
Add get_queryset to CachedOAuth2Validator to enable extensibility

### DIFF
--- a/django_toolkit/oauth2/validators.py
+++ b/django_toolkit/oauth2/validators.py
@@ -11,6 +11,9 @@ cache = caches[toolkit_settings.ACCESS_TOKEN_CACHE_BACKEND]
 
 class CachedOAuth2Validator(OAuth2Validator):
 
+    def get_queryset(self):
+        return AccessToken.objects.select_related('application', 'user')
+
     def validate_bearer_token(self, token, scopes, request):
         if not token:
             return False
@@ -33,10 +36,7 @@ class CachedOAuth2Validator(OAuth2Validator):
         access_token = cache.get(token)
 
         if access_token is None:
-            access_token = AccessToken.objects.select_related(
-                'application',
-                'user'
-            ).get(
+            access_token = self.get_queryset().get(
                 token=token
             )
             now = timezone.now()

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -36,3 +36,27 @@ CACHES = {
     }
 }
 ```
+
+If you want to provide a custom queryset, you can subclass `CachedOAuth2Validator`
+and override the `get_queryset` method.
+
+Example (Python 3):
+
+```python
+# custom_validator.py
+from oauth2_provider.models import AccessToken
+
+from django_toolkit.oauth2.validators import CachedOAuth2Validator
+
+class CustomOAuth2QuerySetValidator(CachedOAuth2Validator):
+
+    def get_queryset(self):
+        return super().get_queryset().prefetch_related(
+            'application__custom_table'
+        )
+
+# settings
+OAUTH2_PROVIDER = {
+    'OAUTH2_VALIDATOR_CLASS': 'custom_validator.CustomOAuth2QuerySetValidator',
+}
+```

--- a/tests/oauth2/test_validators.py
+++ b/tests/oauth2/test_validators.py
@@ -3,8 +3,10 @@ from datetime import timedelta
 
 import pytest
 from django.db import connection
+from django.db.models.query import QuerySet
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from oauth2_provider.models import AccessToken
 
 from django_toolkit.oauth2.validators import CachedOAuth2Validator
 
@@ -127,3 +129,12 @@ class TestCachedOAuth2Validator(object):
             http_request
         )
         assert not is_valid
+
+    def test_get_queryset_should_return_an_access_token_queryset(
+        self,
+        validator,
+    ):
+        queryset = validator.get_queryset()
+
+        assert isinstance(queryset, QuerySet)
+        assert queryset.model == AccessToken


### PR DESCRIPTION
This should enable subclassing of CachedOAuth2Validator to provide a flexible access token retrieval.
This is specially useful when an application uses custom user and/or application models, and a special filter/join is needed.