### PR TITLE
Delete failure cache key when circuit opens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 cache:
   directories:


### PR DESCRIPTION
This is to mitigate the consequences from a key that may be created without timeout.  It may occur when a key expires AFTER the `add` call and it's created in the `incr`, therefore without timeout.
