### PR TITLE
Add support for django-oauth-toolkit version 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,19 @@ cache:
     - $HOME/.cache/pip
 
 install:
-  - pip install "$DJANGO"
+  - pip install "$DEPENDENCIES"
   - pip install -r requirements-dev.txt
 
 env:
   matrix:
-   - DJANGO="Django<1.9"
-   - DJANGO="Django<1.10"
-   - DJANGO="Django<1.11"
-   - DJANGO="Django<1.12"
+   - DEPENDENCIES="'Django<1.9' 'django-oauth-toolkit<1.0.0'"
+   - DEPENDENCIES="'Django<1.9' 'django-oauth-toolkit<1.1.0'"
+   - DEPENDENCIES="'Django<1.10' 'django-oauth-toolkit<1.0.0'"
+   - DEPENDENCIES="'Django<1.10' 'django-oauth-toolkit<1.1.0'"
+   - DEPENDENCIES="'Django<1.11' 'django-oauth-toolkit<1.0.0'"
+   - DEPENDENCIES="'Django<1.11' 'django-oauth-toolkit<1.1.0'"
+   - DEPENDENCIES="'Django<1.12' 'django-oauth-toolkit<1.0.0'"
+   - DEPENDENCIES="'Django<1.12' 'django-oauth-toolkit<1.1.0'"
 
 script:
   - make check coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,15 @@ cache:
     - $HOME/.cache/pip
 
 install:
-  - pip install "$DEPENDENCIES"
+  - pip install "$DJANGO"
   - pip install -r requirements-dev.txt
 
 env:
   matrix:
-   - DEPENDENCIES="'Django<1.9' 'django-oauth-toolkit<1.0.0'"
-   - DEPENDENCIES="'Django<1.9' 'django-oauth-toolkit<1.1.0'"
-   - DEPENDENCIES="'Django<1.10' 'django-oauth-toolkit<1.0.0'"
-   - DEPENDENCIES="'Django<1.10' 'django-oauth-toolkit<1.1.0'"
-   - DEPENDENCIES="'Django<1.11' 'django-oauth-toolkit<1.0.0'"
-   - DEPENDENCIES="'Django<1.11' 'django-oauth-toolkit<1.1.0'"
-   - DEPENDENCIES="'Django<1.12' 'django-oauth-toolkit<1.0.0'"
-   - DEPENDENCIES="'Django<1.12' 'django-oauth-toolkit<1.1.0'"
+    - DJANGO="Django<1.9"
+    - DJANGO="Django<1.10"
+    - DJANGO="Django<1.11"
+    - DJANGO="Django<1.12"
 
 script:
   - make check coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ install:
 
 env:
   matrix:
-    - DJANGO="Django<1.9"
-    - DJANGO="Django<1.10"
     - DJANGO="Django<1.11"
     - DJANGO="Django<1.12"
 

--- a/django_toolkit/middlewares.py
+++ b/django_toolkit/middlewares.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from django.utils.deprecation import MiddlewareMixin
+
 from .shortcuts import get_oauth2_app
 from .toolkit_settings import API_VERSION, MIDDLEWARE_ACCESS_LOG_FORMAT
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
 
 
 logger = logging.getLogger(__name__)

--- a/django_toolkit/oauth2/compat.py
+++ b/django_toolkit/oauth2/compat.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-# flake8: noqa
-
-try:
-    from oauth2_provider.models import get_access_token_model
-    AccessToken = get_access_token_model()
-except ImportError:
-    from oauth2_provider.models import AccessToken

--- a/django_toolkit/oauth2/compat.py
+++ b/django_toolkit/oauth2/compat.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+try:
+    from oauth2_provider.models import get_access_token_model
+    AccessToken = get_access_token_model()
+except ImportError:
+    from oauth2_provider.models import AccessToken

--- a/django_toolkit/oauth2/receivers.py
+++ b/django_toolkit/oauth2/receivers.py
@@ -2,12 +2,12 @@
 from django.core.cache import caches
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from oauth2_provider.models import get_access_token_model
 
 from django_toolkit import toolkit_settings
 
-from .compat import AccessToken
-
 cache = caches[toolkit_settings.ACCESS_TOKEN_CACHE_BACKEND]
+AccessToken = get_access_token_model()
 
 
 @receiver(post_delete, sender=AccessToken)

--- a/django_toolkit/oauth2/receivers.py
+++ b/django_toolkit/oauth2/receivers.py
@@ -2,9 +2,10 @@
 from django.core.cache import caches
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from oauth2_provider.models import AccessToken
 
 from django_toolkit import toolkit_settings
+
+from .compat import AccessToken
 
 cache = caches[toolkit_settings.ACCESS_TOKEN_CACHE_BACKEND]
 

--- a/django_toolkit/oauth2/validators.py
+++ b/django_toolkit/oauth2/validators.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from django.core.cache import caches
 from django.utils import timezone
-from oauth2_provider.models import AccessToken
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
 from django_toolkit import toolkit_settings
+
+from .compat import AccessToken
+
 
 cache = caches[toolkit_settings.ACCESS_TOKEN_CACHE_BACKEND]
 

--- a/django_toolkit/oauth2/validators.py
+++ b/django_toolkit/oauth2/validators.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 from django.core.cache import caches
 from django.utils import timezone
+from oauth2_provider.models import get_access_token_model
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
 from django_toolkit import toolkit_settings
 
-from .compat import AccessToken
-
-
 cache = caches[toolkit_settings.ACCESS_TOKEN_CACHE_BACKEND]
+AccessToken = get_access_token_model()
 
 
 class CachedOAuth2Validator(OAuth2Validator):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -e .
 bumpversion==0.5.3
-django-oauth-toolkit==0.12.0
 djangorestframework==3.6.2
 flake8==3.3.0
 isort==4.2.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -e .
 bumpversion==0.5.3
+django-oauth-toolkit==1.0.0
 djangorestframework==3.6.2
 flake8==3.3.0
 isort==4.2.5

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'Django>=1.8',
     ],
     extras_require={
-        'oauth2': ['django-oauth-toolkit'],
+        'oauth2': ['django-oauth-toolkit==1.0.0'],
     },
     packages=find_packages(exclude=[
         'tests*'

--- a/tests/oauth2/conftest.py
+++ b/tests/oauth2/conftest.py
@@ -5,7 +5,9 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
 from django.utils import timezone
-from oauth2_provider.models import AccessToken, get_application_model
+from oauth2_provider.models import get_application_model
+
+from django_toolkit.oauth2.compat import AccessToken
 
 
 @pytest.fixture(autouse=True)

--- a/tests/oauth2/conftest.py
+++ b/tests/oauth2/conftest.py
@@ -5,9 +5,10 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
 from django.utils import timezone
-from oauth2_provider.models import get_application_model
-
-from django_toolkit.oauth2.compat import AccessToken
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_application_model
+)
 
 
 @pytest.fixture(autouse=True)
@@ -51,6 +52,7 @@ def application(user):
 
 @pytest.fixture
 def access_token(application, scopes):
+    AccessToken = get_access_token_model()
     return AccessToken.objects.create(
         scope=' '.join(scopes),
         expires=timezone.now() + timedelta(seconds=300),

--- a/tests/oauth2/test_validators.py
+++ b/tests/oauth2/test_validators.py
@@ -6,8 +6,8 @@ from django.db import connection
 from django.db.models.query import QuerySet
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
-from oauth2_provider.models import AccessToken
 
+from django_toolkit.oauth2.compat import AccessToken
 from django_toolkit.oauth2.validators import CachedOAuth2Validator
 
 

--- a/tests/oauth2/test_validators.py
+++ b/tests/oauth2/test_validators.py
@@ -6,8 +6,8 @@ from django.db import connection
 from django.db.models.query import QuerySet
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from oauth2_provider.models import get_access_token_model
 
-from django_toolkit.oauth2.compat import AccessToken
 from django_toolkit.oauth2.validators import CachedOAuth2Validator
 
 
@@ -137,4 +137,4 @@ class TestCachedOAuth2Validator(object):
         queryset = validator.get_queryset()
 
         assert isinstance(queryset, QuerySet)
-        assert queryset.model == AccessToken
+        assert queryset.model == get_access_token_model()

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 import pytest
 from mixer.backend.django import mixer
-from oauth2_provider.models import get_application_model
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_application_model
+)
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from django_toolkit import shortcuts
-from django_toolkit.oauth2.compat import AccessToken
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
 
 
 @pytest.mark.django_db

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,19 +1,26 @@
 # -*- coding: utf-8 -*-
 import pytest
 from mixer.backend.django import mixer
-from oauth2_provider.models import AccessToken, Application
+from oauth2_provider.models import get_application_model
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from django_toolkit import shortcuts
+from django_toolkit.oauth2.compat import AccessToken
+
+Application = get_application_model()
 
 
 @pytest.mark.django_db
 class TestGetCurrentApp(object):
 
     @pytest.fixture
-    def token(self):
-        return mixer.blend(AccessToken)
+    def application(self):
+        return mixer.blend(Application)
+
+    @pytest.fixture
+    def token(self, application):
+        return mixer.blend(AccessToken, application=application)
 
     def test_should_return_the_client_applicaton(self, token):
         factory = APIRequestFactory()


### PR DESCRIPTION
The new version (`1.0.0`) of [django-oauth-toolkit](https://github.com/evonove/django-oauth-toolkit) has support for AbstractAccessToken model.

`django-toolkit` is currently trying to import the model directly and not using the `get_access_token_model` function that makes sure the correct model is being imported.
