### PR TITLE
Update docs theme back to "readthedocs"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,2 @@
 site_name: LuizaLabs Django Toolkit
+theme: readthedocs


### PR DESCRIPTION
Until the [version 1.5](https://django-toolkit.readthedocs.io/en/1.5.0/), the documentation used the theme "read the docs". The [version 1.6](https://django-toolkit.readthedocs.io/en/1.6.0/) used the new default theme, which does not work well with narrower browser windows and the way or pages are structured.

![luizalabs_django_toolkit](https://user-images.githubusercontent.com/136425/46429639-517e2280-c71d-11e8-9269-65e2234f591c.png)
