### PR TITLE
create cache of failure on circuit breaker when increase request count

### DIFF
--- a/django_toolkit/fallbacks/circuit_breaker/circuit_breaker.py
+++ b/django_toolkit/fallbacks/circuit_breaker/circuit_breaker.py
@@ -108,5 +108,9 @@ class CircuitBreaker:
         self.cache.add(self.rule.request_cache_key, 0, self.failure_timeout)
         # To calculate the exact percentage, the cache of requests and the
         # cache of failures must expire at the same time.
-        self.cache.add(self.rule.failure_cache_key, 0, self.failure_timeout)
+        if self.rule.should_increase_failure_count():
+            self.cache.add(
+                self.rule.failure_cache_key, 0, self.failure_timeout
+            )
+
         self.cache.incr(self.rule.request_cache_key)

--- a/django_toolkit/fallbacks/circuit_breaker/circuit_breaker.py
+++ b/django_toolkit/fallbacks/circuit_breaker/circuit_breaker.py
@@ -90,9 +90,7 @@ class CircuitBreaker:
 
         # Between the cache.add and cache.incr, the cache MAY expire,
         # which will lead to a circuit that will eventually open
-        self.cache.add(
-            self.rule.failure_cache_key, 0, self.failure_timeout
-        )
+        self.cache.add(self.rule.failure_cache_key, 0, self.failure_timeout)
         total = self.cache.incr(self.rule.failure_cache_key)
 
         self.rule.log_increase_failures(
@@ -107,7 +105,8 @@ class CircuitBreaker:
         ):
             return
 
-        self.cache.add(
-            self.rule.request_cache_key, 0, self.failure_timeout
-        )
+        self.cache.add(self.rule.request_cache_key, 0, self.failure_timeout)
+        # To calculate the exact percentage, the cache of requests and the
+        # cache of failures must expire at the same time.
+        self.cache.add(self.rule.failure_cache_key, 0, self.failure_timeout)
         self.cache.incr(self.rule.request_cache_key)

--- a/tests/fallbacks/circuit_breaker/test_circuit_breaker.py
+++ b/tests/fallbacks/circuit_breaker/test_circuit_breaker.py
@@ -323,3 +323,21 @@ class TestCircuitBreaker:
 
         assert cache.get(failure_cache_key) is None
         assert cache.get(request_cache_key) is None
+
+    def test_should_create_failure_cache_when_increase_request_count(
+        self,
+        rule_should_not_increase_failure,
+        failure_cache_key,
+        request_cache_key,
+    ):
+        assert cache.get(failure_cache_key) is None
+
+        with CircuitBreaker(
+            rule=rule_should_not_increase_failure,
+            cache=cache,
+            failure_exception=MyException,
+            catch_exceptions=(ValueError,),
+        ):
+            success_function()
+
+        assert cache.get(failure_cache_key) == 0

--- a/tests/fallbacks/circuit_breaker/test_circuit_breaker.py
+++ b/tests/fallbacks/circuit_breaker/test_circuit_breaker.py
@@ -326,14 +326,14 @@ class TestCircuitBreaker:
 
     def test_should_create_failure_cache_when_increase_request_count(
         self,
-        rule_should_not_increase_failure,
+        rule_should_not_open,
         failure_cache_key,
         request_cache_key,
     ):
         assert cache.get(failure_cache_key) is None
 
         with CircuitBreaker(
-            rule=rule_should_not_increase_failure,
+            rule=rule_should_not_open,
             cache=cache,
             failure_exception=MyException,
             catch_exceptions=(ValueError,),


### PR DESCRIPTION
Create cache of failure when circuit breaker increase request count, because to calculate the exact percentage, the cache of requests and the cache of failures must expire at the same time.