### PR TITLE
Drop support for python 3.4 and add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 cache:
   directories:


### PR DESCRIPTION
Remove CI tests with python 3.4 and add 3.7.